### PR TITLE
[fix] mismatch in example demo

### DIFF
--- a/examples/example-demo.typ
+++ b/examples/example-demo.typ
@@ -7,7 +7,7 @@
 ///  #example(`#example-demo.flashy[Change code to preview ratio]`, ratio: 2)
 ///  ```/// #example(`#example-demo.flashy(map: color.map.vlag)[Huge preview]`, scale-preview: 200%)```
 ///  #example(`#example-demo.flashy(map: color.map.vlag)[Huge preview]`, scale-preview: 200%)
-///  ```/// #example(`#flashy[Add to scope]`, scope: (flashy: example-demo.flashy, i: 2))```
+///  ```/// #example(`#flashy[Add to scope #i ...]`, scope: (flashy: example-demo.flashy, i: 2))```
 ///  #example(`#flashy[Add to scope #i ...]`, scope: (flashy: example-demo.flashy, i: 2))
 ///
 /// \


### PR DESCRIPTION
The text in the code block did not match the actual code used in the example.