### PR TITLE
add possibility to set module description and show it

### DIFF
--- a/src/parse-module.typ
+++ b/src/parse-module.typ
@@ -117,6 +117,10 @@
   /// -> str
   name: "", 
 
+  /// The description for the module.
+  /// -> content | str
+  description: none,
+
   /// The label-prefix for internal function references. If `auto`, the 
   /// label-prefix name will be the module name. 
   /// -> auto | str
@@ -163,6 +167,7 @@
     docs.functions = resolve-parents(docs.functions)
   }
 
+  if description != none {docs.description = description}
   
   return docs
 }

--- a/src/show-module.typ
+++ b/src/show-module.typ
@@ -33,6 +33,10 @@
   /// -> bool
   show-module-name: true,
 
+  /// Whether to output the module description under the module name.
+  /// -> bool
+  show-module-description: false,
+
   /// Whether to allow breaking of parameter description blocks. 
   /// -> bool
   break-param-descriptions: false,
@@ -183,6 +187,11 @@
   
   if "name" in module-doc and show-module-name and module-doc.name != "" {
     heading(module-doc.name, level: first-heading-level)
+    parbreak()
+  }
+
+  if "description" in module-doc and show-module-description and module-doc.description != none {
+    module-doc.description
     parbreak()
   }
   


### PR DESCRIPTION
Hi,
I appreciate tiny and have used it for a while. For my documentation, I need the possibility to show a module description as part of show-module(), though. I saw that the new parser for the module seems to look for a module description but I couldn't find out how to implement such a description. Since I think that including the module description when calling parse-module() in the docs document is sufficient (giving the possibility to add another description depending on only documenting this specific module or a bunch of modules as one), I implemented that.

Newly added:
* parameter description in parse-module to set a module description
* parameter show-module-description in show-module to set if module description should be shown

It works for my use-case and I think it should be backwards-compatible.